### PR TITLE
Removing reference to tr1 since memory is standard across compilers now

### DIFF
--- a/src/ofxState.h
+++ b/src/ofxState.h
@@ -32,14 +32,8 @@
 #pragma once
 
 #include "ofEvents.h"
-#ifdef TARGET_WIN32
 #include <memory>
-#else
-#include <tr1/memory>
-#endif
 #include "ofMain.h"
-
-using namespace tr1;
 
 namespace itg
 {

--- a/src/ofxStateMachine.h
+++ b/src/ofxStateMachine.h
@@ -31,18 +31,13 @@
  */
 #pragma once
 
-#ifdef TARGET_WIN32
 #include <memory>
-#else
-#include <tr1/memory>
-#endif
 #include <map>
 #include <string>
 #include <iostream>
 #include "ofxState.h"
 
 using namespace std;
-using namespace tr1;
 
 namespace itg
 {


### PR DESCRIPTION
I don't have a linux machine to test this on, but removing this allows ofxStateMachine to be used on osx now.
